### PR TITLE
Fix typo. Fix HAuthTicket type

### DIFF
--- a/init.go
+++ b/init.go
@@ -55,7 +55,7 @@ func initApi() {
 		panic(err)
 	}
 
-	purego.RegisterLibFunc(&restartAppiIfNecessary, steamAPILib, flatAPI_RestartAppIfNecessary)
+	purego.RegisterLibFunc(&restartAppIfNecessary, steamAPILib, flatAPI_RestartAppIfNecessary)
 	purego.RegisterLibFunc(&initFlat, steamAPILib, flatAPI_InitFlat)
 	purego.RegisterLibFunc(&Shutdown, steamAPILib, flatAPI_Shutdown)
 	purego.RegisterLibFunc(&WriteMiniDump, steamAPILib, flatAPI_WriteMiniDump)

--- a/methods.go
+++ b/methods.go
@@ -6438,7 +6438,7 @@ const (
 	EAuthSessionResponse_AuthTicketNetworkIdentityFailure EAuthSessionResponse = 10
 )
 
-type HAuthTicket uint
+type HAuthTicket uint32
 
 type EVoiceResult int32
 

--- a/steam_methods.go
+++ b/steam_methods.go
@@ -40,7 +40,7 @@ func (s *steamErrMsg) String() string {
 }
 
 var (
-	restartAppiIfNecessary     func(int) uintptr
+	restartAppIfNecessary      func(int) uintptr
 	initFlat                   func(*steamErrMsg) uintptr
 	Shutdown                   func()
 	WriteMiniDump              func(uStructuredExceptionCode uint32, pvExceptionInfo []byte, uBuildID uint32)
@@ -55,8 +55,8 @@ func SetDebugMode(debugEnabled bool) {
 	debugMode = debugEnabled
 }
 
-func RestartAppiIfNecessary(appID uint32) bool {
-	result := restartAppiIfNecessary(int(appID))
+func RestartAppIfNecessary(appID uint32) bool {
+	result := restartAppIfNecessary(int(appID))
 	return byte(result) != 0
 }
 


### PR DESCRIPTION
Hey, Thanks again for making the library. Works like a charm! I only had two issues:
1. restartAppIfNecessary had a typo in it: Previously: `restartAppiIfNecessary`. Note: This change does alter the public facing interface a bit.
2. The type of `HAuthTicket` was slightly wrong (uint -> uint32). Steam docs have it as a uint32: https://partner.steamgames.com/doc/api/steam_api#HAuthTicket - In the previous version I wasn't able to decode any data returned by the associated callback ( https://partner.steamgames.com/doc/api/ISteamUser#GetAuthTicketForWebApi ) because the offsets were wrong. But after this change everything worked great!

Testing wise: I only tested this on my windows build of my steam app. I'll eventually test it on my Linux build. Unfortunately I don't have a mac so I can't test anything related to MacOS builds. Sorry.

Let me know if you see any issues. I'm not really an expert on purego stuff.

Thanks Again,
Unit